### PR TITLE
feat: add comments for tooltip config properties

### DIFF
--- a/src/types/tooltipLocalConfig.ts
+++ b/src/types/tooltipLocalConfig.ts
@@ -7,6 +7,7 @@ type TooltipLocalConfig = {
      */
 
     content: string,
+    
     /**
      * Define whether tooltip should be shown on hover (enabled/disabled).
      */

--- a/src/types/tooltipLocalConfig.ts
+++ b/src/types/tooltipLocalConfig.ts
@@ -1,8 +1,20 @@
 import TooltipConfig from "./tooltipConfig"
 
 type TooltipLocalConfig = {
+    /**
+     * REQUIRED. Tooltip text.
+     * Text is rendered as HTML, thus it's possible to give simple HTML structure, e.g., <h1>Tooltip text</h1>
+     */
+
     content: string,
+    /**
+     * Define whether tooltip should be shown on hover (enabled/disabled).
+     */
     show?: boolean,
+
+    /**
+     * Define whether to show tooltip (on mount) without needing hover trigger.
+     */
     alwaysOn?: boolean,
 } & TooltipConfig
 

--- a/src/types/tooltipLocalConfig.ts
+++ b/src/types/tooltipLocalConfig.ts
@@ -5,9 +5,8 @@ type TooltipLocalConfig = {
      * REQUIRED. Tooltip text.
      * Text is rendered as HTML, thus it's possible to give simple HTML structure, e.g., <h1>Tooltip text</h1>
      */
-
     content: string,
-    
+
     /**
      * Define whether tooltip should be shown on hover (enabled/disabled).
      */


### PR DESCRIPTION
Add comments for tooltip config properties so we can get IDE hints when hovering over them.

```typescript
import TooltipConfig from "./tooltipConfig"

type TooltipLocalConfig = {
    /**
     * REQUIRED. Tooltip text.
     * Text is rendered as HTML, thus it's possible to give simple HTML structure, e.g., <h1>Tooltip text</h1>
     */
    content: string,
    
    /**
     * Define whether tooltip should be shown on hover (enabled/disabled).
     */
    show?: boolean,

    /**
     * Define whether to show tooltip (on mount) without needing hover trigger.
     */
    alwaysOn?: boolean,
} & TooltipConfig

export default TooltipLocalConfig
```

![image](https://github.com/user-attachments/assets/c4f99fcb-8d59-4b4f-97af-967782dc9203)
